### PR TITLE
Changed port to match latest version of discovery-cli which uses 3333…

### DIFF
--- a/src/utils/getEnigmaInit.js
+++ b/src/utils/getEnigmaInit.js
@@ -12,7 +12,7 @@ export default async () => {
             web3,
             EnigmaContract.networks['4447'].address,
             EnigmaTokenContract.networks['4447'].address,
-            'http://localhost:3346',
+            'http://localhost:3333',
             {
                 gas: 4712388,
                 gasPrice: 100000000000,


### PR DESCRIPTION
…, to fix dApp network error.

Hi @lacabra, I'm not sure if this is the best way to fix this. I got a `network error` after updating to the latest `discovery-cli` and noticed that the port had changed from 3346 to 3333. I think `discovery init` is pulling from here. 